### PR TITLE
Feat/v1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubnub/tomato",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "CLI mock server for contract testing",
   "main": "dist/index.js",
   "type": "module",

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -12,7 +12,7 @@ import { Settings } from '../components/settings/index.js'
 import { SettingsProvider } from '../components/settings/provider.js'
 import { TypeScriptCompiler } from '../components/compiler/typescript.js'
 
-const VERSION = '1.7.0'
+const VERSION = '1.8.0'
 
 export async function serve(argv: Argv) {
   try {

--- a/src/components/assertions/record-matcher.ts
+++ b/src/components/assertions/record-matcher.ts
@@ -13,6 +13,15 @@ export class RecordMatcher<O> extends Matcher<O, Record<string, any>> {
     )
   }
 
+  has = this.makeAssertion(
+    (actual, key: string) => {
+      return key in actual
+    },
+    (key) => `contain key "${key}"`
+  )
+
+  have = this.has
+
   deepEquals = this.makeAssertion(
     (actual, other: Record<string, any>) => {
       try {

--- a/src/components/runtime/context/validation.ts
+++ b/src/components/runtime/context/validation.ts
@@ -14,3 +14,5 @@ export const assert = {
     body: new UnknownMatcher<MockRequest>('body', (req) => req.body),
   },
 }
+
+assert.request.$query.doesnt.have('lmao')

--- a/src/components/runtime/context/validation.ts
+++ b/src/components/runtime/context/validation.ts
@@ -14,5 +14,3 @@ export const assert = {
     body: new UnknownMatcher<MockRequest>('body', (req) => req.body),
   },
 }
-
-assert.request.$query.doesnt.have('lmao')


### PR DESCRIPTION
Adds `.has (with `.have` variant) to RecordMatcher.

Usage:
```
assert.request.$query.has('name')
assert.request.$query.doesnt.have('surname')
``` 

> Note: `assert.request.$query` is a typed alternative to `assert.request.query`